### PR TITLE
Add values to correct bucket

### DIFF
--- a/prometheus/examples_test.go
+++ b/prometheus/examples_test.go
@@ -16,12 +16,13 @@ package prometheus_test
 import (
 	"bytes"
 	"fmt"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"math"
 	"net/http"
 	"runtime"
 	"strings"
 	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	//nolint:staticcheck // Ignore SA1019. Need to keep deprecated package for compatibility.
 	"github.com/golang/protobuf/proto"
@@ -556,12 +557,12 @@ func ExampleNewConstHistogram() {
 	lp := dto.LabelPair{Name: &n, Value: &v}
 	var labelPairs []*dto.LabelPair
 	labelPairs = append(labelPairs, &lp)
-	val := float64(42)
+	vals := []float64{24.0, 42.0, 89.0, 157.0}
 	t, _ := time.Parse("unix", "Mon Jan _2 15:04:05 MST 2006")
 	ts := timestamppb.New(t)
 
 	for i := 0; i < 4; i++ {
-		e := dto.Exemplar{Label: labelPairs, Value: &val, Timestamp: ts}
+		e := dto.Exemplar{Label: labelPairs, Value: &vals[i], Timestamp: ts}
 		exemplars = append(exemplars, &e)
 	}
 
@@ -605,7 +606,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 24
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >
@@ -633,7 +634,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 89
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >
@@ -647,7 +648,7 @@ func ExampleNewConstHistogram() {
 	//         name: "testName"
 	//         value: "testVal"
 	//       >
-	//       value: 42
+	//       value: 157
 	//       timestamp: <
 	//         seconds: -62135596800
 	//       >

--- a/prometheus/histogram.go
+++ b/prometheus/histogram.go
@@ -582,7 +582,9 @@ func (h *constHistogram) Desc() *Desc {
 
 func (h *constHistogram) Write(out *dto.Metric) error {
 	his := &dto.Histogram{}
+	// h.buckets, buckets and bounds are all the same length
 	buckets := make([]*dto.Bucket, 0, len(h.buckets))
+	bounds := make([]float64, 0)
 
 	his.SampleCount = proto.Uint64(h.count)
 	his.SampleSum = proto.Float64(h.sum)
@@ -591,24 +593,24 @@ func (h *constHistogram) Write(out *dto.Metric) error {
 			CumulativeCount: proto.Uint64(count),
 			UpperBound:      proto.Float64(upperBound),
 		})
+		bounds = append(bounds, upperBound)
 	}
 
+	// make sure that both bounds and buckets have the same ordering
 	if len(buckets) > 0 {
 		sort.Sort(buckSort(buckets))
 	}
+	sort.Float64s(bounds)
 
 	if len(h.exemplars) > 0 {
 		r := len(buckets)
-		if len(h.exemplars) < r {
-			r = len(h.exemplars)
-		} else {
-			//check if there is an exemplar for upperbound bucket
-			if e := h.exemplars[r-1]; e != nil {
-				buckets[r-1].Exemplar = h.exemplars[r-1]
-			}
-		}
 		for i := 0; i < r; i++ {
-			buckets[i].Exemplar = h.exemplars[i]
+			bound := sort.SearchFloat64s(bounds, *h.exemplars[i].Value)
+			// Only append the exemplar if it's within the bounds defined in the
+			// buckets.
+			if bound < r {
+				buckets[bound].Exemplar = h.exemplars[i]
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit fixes a few small issues with how the exemplars are added on the const histogram. First it makes sure that exemplar values are added to the correct bucket regardless of the ordering of either the buckets or the exemplars. Second, it also makes it so there can be a different number of buckets and exemplar and still have the function work without errors or panics.

Signed-off-by: William Perron <william.perron@shopify.com>